### PR TITLE
半分しか描画されないスプライトを全面が表示されるように修正

### DIFF
--- a/Sprite.cpp
+++ b/Sprite.cpp
@@ -62,8 +62,8 @@ void Sprite::Draw()
 	// SRVのDescriptorHeapの場所を設定
 	
 	// 描画
-	//commandList->DrawInstanced(6, 1, 0, 0);
-	spriteCommon->GetDxCommon()->GetCommandList()->DrawIndexedInstanced(6, 1, 0, 0, 0);
+	spriteCommon->GetDxCommon()->GetCommandList()->DrawInstanced(6, 1, 0, 0);
+	//spriteCommon->GetDxCommon()->GetCommandList()->DrawIndexedInstanced(6, 1, 0, 0, 0);
 }
 
 void Sprite::CreateVertexResourceData()


### PR DESCRIPTION
Sprite::Draw() メソッドの描画コマンドを変更

Sprite::Draw() メソッド内で、以前は `DrawIndexedInstanced` メソッドを使用して描画を行っていましたが、これがコメントアウトされ、代わりに `DrawInstanced` メソッドが使用されるようになりました。