### PR TITLE
メモリリーク改善

### DIFF
--- a/DirectXCommon.cpp
+++ b/DirectXCommon.cpp
@@ -285,7 +285,6 @@ void DirectXCommon::InitRenderTargetView()
 	// ディスクリプタの先頭を取得する
 	D3D12_CPU_DESCRIPTOR_HANDLE rtvStartHandle = rtvDescriptorHeap->GetCPUDescriptorHandleForHeapStart();
 
-	// エラーが出たら　rtvHandles=rtvStartHandleをfor分の外へ　rtvHandles[0] = rtvStartHandle;
 
 	for (uint32_t i = 0; i < 2; ++i) {
 		rtvHandles[i] = rtvStartHandle;

--- a/TextureManager.cpp
+++ b/TextureManager.cpp
@@ -56,7 +56,8 @@ void TextureManager::Initialize(DirectXCommon* dxCommon)
 }
 
 void TextureManager::Finalize()
-{
+{// テクスチャデータのクリア
+	textureDatas.clear();
 }
 
 void TextureManager::LoadTexture(const std::string& filePath)


### PR DESCRIPTION
`DirectXCommon`と`TextureManager`の関数修正

`DirectXCommon::InitRenderTargetView`関数で`rtvHandles`の初期化を`for`ループ内に移動しました。これにより、各要素がループ内で設定されるようになりました。

`TextureManager::Initialize`関数での`textureDatas`のクリア処理を`TextureManager::Finalize`関数に追加しました。これにより、`Finalize`関数が呼ばれた際に`textureDatas`がクリアされるようになりました。