### PR TITLE
`sprites2`関連の操作をコメントアウトし、新しいスプライトを追加

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -169,12 +169,18 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 
 #pragma region 最初のシーンの初期化
 	std::vector<Sprite*> sprites;
-	std::vector<Sprite*> sprites2;
+	//std::vector<Sprite*> sprites2;
     sprites.clear();
-	sprites2.clear();
+	//sprites2.clear();
+	Sprite* sprite = new Sprite();
+	sprite->Initialize(spriteCommon, "resources/uvChecker.png");
+	Vector2 pos = { 0.0f, 0.0f };
+	sprite->SetPosition(pos);
+	//Vector2 size = { 100.0f, 100.0f };
+	//sprite->SetSize(size);
+	sprites.push_back(sprite);
 	
-	
-	for (uint32_t i = 0; i < 5; ++i) {
+	/*for (uint32_t i = 0; i < 5; ++i) {
 		Sprite* sprite = new Sprite();
 		sprite->Initialize(spriteCommon, "resources/uvChecker.png");
 		Vector2 pos = { 100.0f * i, 100.0f };
@@ -191,7 +197,7 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 		Vector2 size = { 100.0f, 100.0f };
 		sprite2->SetSize(size);
 		sprites.push_back(sprite2);
-	}
+	}*/
 #pragma endregion
 
 
@@ -641,9 +647,9 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 		for (Sprite* sprite : sprites) {
 			sprite->Draw();
 		}
-		for (Sprite* sprite2 : sprites2) {
+		/*for (Sprite* sprite2 : sprites2) {
 			sprite2->Draw();
-		}
+		}*/
 
 		//
 		//		// スフィア用の設定
@@ -697,9 +703,9 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 	//OutputDebugStringA("Hello,DirectX!\n");
 
 	//解放
-	for (Sprite* sprite2 : sprites2) {
+	/*for (Sprite* sprite2 : sprites2) {
 		delete sprite2;
-	}
+	}*/
 	for (Sprite* sprite : sprites) {
 		delete sprite;
 	}


### PR DESCRIPTION
`sprites2`という名前の`std::vector<Sprite*>`の変数がコメントアウトされました。これにより、`sprites2`に関連するすべての操作（クリア、描画、解放）がコメントアウトされました。新しい`Sprite`オブジェクトが作成され、`sprites`ベクターに追加されました。このスプライトは`"resources/uvChecker.png"`というリソースを使用して初期化され、位置が設定されました。以前のループで複数のスプライトを作成していた部分がコメントアウトされました。これにより、ループ内でスプライトを作成して`sprites`ベクターに追加する処理が無効化されました。