### PR TITLE
確認完了06_01

### DIFF
--- a/CG2_DirectX.vcxproj
+++ b/CG2_DirectX.vcxproj
@@ -110,6 +110,8 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClCompile Include="Logger.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="MakeMatrix.cpp" />
+    <ClCompile Include="Object3D.cpp" />
+    <ClCompile Include="Object3DCommon.cpp" />
     <ClCompile Include="Sprite.cpp" />
     <ClCompile Include="SpriteCommon.cpp" />
     <ClCompile Include="StringUtility.cpp" />
@@ -131,6 +133,8 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClInclude Include="Logger.h" />
     <ClInclude Include="MakeMatrix.h" />
     <ClInclude Include="Math.h" />
+    <ClInclude Include="Object3D.h" />
+    <ClInclude Include="Object3DCommon.h" />
     <ClInclude Include="Sprite.h" />
     <ClInclude Include="SpriteCommon.h" />
     <ClInclude Include="StringUtility.h" />

--- a/CG2_DirectX.vcxproj.filters
+++ b/CG2_DirectX.vcxproj.filters
@@ -72,6 +72,12 @@
     <ClCompile Include="TextureManager.cpp">
       <Filter>ソース ファイル</Filter>
     </ClCompile>
+    <ClCompile Include="Object3DCommon.cpp">
+      <Filter>ソース ファイル</Filter>
+    </ClCompile>
+    <ClCompile Include="Object3D.cpp">
+      <Filter>ソース ファイル</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Math.h">
@@ -129,6 +135,12 @@
       <Filter>ヘッダー ファイル</Filter>
     </ClInclude>
     <ClInclude Include="TextureManager.h">
+      <Filter>ヘッダー ファイル</Filter>
+    </ClInclude>
+    <ClInclude Include="Object3DCommon.h">
+      <Filter>ヘッダー ファイル</Filter>
+    </ClInclude>
+    <ClInclude Include="Object3D.h">
       <Filter>ヘッダー ファイル</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Object3D.cpp
+++ b/Object3D.cpp
@@ -1,0 +1,5 @@
+#include "Object3D.h"
+
+void Object3D::Initialize()
+{
+}

--- a/Object3D.h
+++ b/Object3D.h
@@ -1,0 +1,9 @@
+#pragma once
+// 3Dオブジェクト
+class Object3D
+{
+public:	// メンバ関数
+	// 初期化
+	void Initialize();
+};
+

--- a/Object3DCommon.cpp
+++ b/Object3DCommon.cpp
@@ -1,0 +1,5 @@
+#include "Object3DCommon.h"
+
+void Object3DCommon::Initialize()
+{
+}

--- a/Object3DCommon.h
+++ b/Object3DCommon.h
@@ -1,0 +1,10 @@
+#pragma once
+
+// 3Dオブジェクト共通部
+class Object3DCommon
+{
+public:	// メンバ関数
+	// 初期化
+	void Initialize();
+};
+

--- a/main.cpp
+++ b/main.cpp
@@ -27,6 +27,8 @@
 #include "Sprite.h"
 #include "SpriteCommon.h"
 #include "TextureManager.h"
+#include "Object3D.h"
+#include "Object3DCommon.h"
 
 using namespace Logger;
 #pragma comment(lib,"d3d12.lib")
@@ -164,10 +166,20 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 	// スプライト共通部の初期化
 	SpriteCommon* spriteCommon = new SpriteCommon();
 	spriteCommon->Initialize(dxCommon);
+
+	// 3Dオブジェクト共通部の初期化
+	Object3DCommon* object3DCommon = new Object3DCommon();
+	object3DCommon->Initialize();
+
+
 #pragma endregion 
 
 
 #pragma region 最初のシーンの初期化
+	// 
+	Object3D* object3D = new Object3D();
+	object3D->Initialize();
+
 	std::vector<Sprite*> sprites;
 	//std::vector<Sprite*> sprites2;
     sprites.clear();
@@ -198,6 +210,8 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 		sprite2->SetSize(size);
 		sprites.push_back(sprite2);
 	}*/
+
+
 #pragma endregion
 
 
@@ -709,6 +723,8 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 	for (Sprite* sprite : sprites) {
 		delete sprite;
 	}
+	delete object3D;
+	delete object3DCommon;
 	delete spriteCommon;
 	delete dxCommon;
 	delete input;


### PR DESCRIPTION
Object3D と Object3DCommon の追加と初期化コードの実装

`CG2_DirectX.vcxproj` に `Object3D.cpp` と `Object3DCommon.cpp` をソースファイルとして追加し、`Object3D.h` と `Object3DCommon.h` をヘッダーファイルとして追加しました。 `CG2_DirectX.vcxproj.filters` において、これらのファイルを適切なフィルターに追加しました。 `main.cpp` に `Object3D.h` と `Object3DCommon.h` のインクルードを追加し、`WinMain` 関数内で `Object3DCommon` と `Object3D` の初期化および削除コードを追加しました。 `Object3D.cpp` と `Object3DCommon.cpp` にそれぞれのクラスの初期化メソッドを追加し、`Object3D.h` と `Object3DCommon.h` にクラス定義を追加しました。