### PR TITLE
色替えから

### DIFF
--- a/Math.h
+++ b/Math.h
@@ -11,6 +11,18 @@ struct Vector3 {
 	float x;
 	float y;
 	float z;
+	Vector3 operator+=(const Vector3& other) const {
+		return Vector3(x + other.x, y + other.y, z + other.z);
+	}
+	Vector3 operator-=(const Vector3& other) const {
+		return Vector3(x - other.x, y - other.y, z - other.z);
+	}
+	Vector3 operator*=(float scale) const {
+		return Vector3(x * scale, y * scale, z * scale);
+	}
+	Vector3 operator/=(float scale) const {
+		return Vector3(x / scale, y / scale, z / scale);
+	}
 };
 struct Vector4 {
 	float x;

--- a/imgui.ini
+++ b/imgui.ini
@@ -30,6 +30,6 @@ Collapsed=0
 
 [Window][plane]
 Pos=83,68
-Size=256,90
+Size=256,107
 Collapsed=0
 


### PR DESCRIPTION
Vector3演算子追加、Particle構造体と更新処理の実装

`Math.h` に `Vector3` の演算子オーバーロードを追加。
`imgui.ini` のウィンドウサイズを変更。
`main.cpp` のインクルードディレクティブをフォーマットし、`<random>` ヘッダーを追加。 `Particle` 構造体と `kDeltaTime` 定数を追加。
`MakeParticle` 関数を追加し、ランダムな位置と速度を持つ `Particle` を生成。 `WinMain` 関数内で `Transform` 配列を `Particle` 配列に置き換え、初期化を実装。 ランダムエンジンの初期化を追加。
各フレームごとに `Particle` の位置を更新する処理を追加。
ImGui の UI コードを `particles` に対応するように変更。