### PR TITLE
確認分完了

### DIFF
--- a/Object3DCommon.cpp
+++ b/Object3DCommon.cpp
@@ -1,5 +1,166 @@
 #include "Object3DCommon.h"
+#include "Logger.h"
 
-void Object3DCommon::Initialize()
+void Object3DCommon::Initialize(DirectXCommon* dxCommon)
 {
+	dxCommon_ = dxCommon;
+	CreateGraficsPipeLine();
+}
+
+void Object3DCommon::DrawSettingCommon()
+{
+	// ルートシグネチャのセット
+	dxCommon_->GetCommandList()->SetGraphicsRootSignature(rootSignature.Get());
+	// グラフィックスパプラインのセット
+	dxCommon_->GetCommandList()->SetPipelineState(graphicsPipelineState.Get());
+	// プリミティブトポロジーのセット
+	dxCommon_->GetCommandList()->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+}
+
+
+void Object3DCommon::CreateRootSignatrue()
+{
+#pragma region RootParameter
+	//RootSignature作成
+	descriptionRootSignature.Flags =
+		D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT;
+#pragma region DescriptorRange
+	D3D12_DESCRIPTOR_RANGE descriptorRange[1] = {};
+	descriptorRange[0].BaseShaderRegister = 0;//0から始まる
+	descriptorRange[0].NumDescriptors = 1;//数は１つ
+	descriptorRange[0].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;//SRVを使う
+	descriptorRange[0].OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;//offsetを自動計算
+#pragma endregion
+
+	//RootParamater作成。複数設定できるので配列。今回は結果が１つだけなので長さ１の配列
+	D3D12_ROOT_PARAMETER rootParamaters[4] = {};
+	rootParamaters[0].ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;//CBVを使う
+	rootParamaters[0].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;//PixelShaderで使う
+	rootParamaters[0].Descriptor.ShaderRegister = 0;//レジスタ番号０とバインド
+
+	rootParamaters[1].ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;//
+	rootParamaters[1].ShaderVisibility = D3D12_SHADER_VISIBILITY_VERTEX;//
+	rootParamaters[1].Descriptor.ShaderRegister = 0;//
+
+	rootParamaters[2].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;//DescriptorTableを使う
+	rootParamaters[2].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;//PixelShaderで使う
+	rootParamaters[2].DescriptorTable.pDescriptorRanges = descriptorRange;//Tableの中身の配列を指定
+	rootParamaters[2].DescriptorTable.NumDescriptorRanges = _countof(descriptorRange);//Tableで利用する数
+
+	rootParamaters[3].ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;	//CBVで使う
+	rootParamaters[3].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;	//PixelShaderで使う
+	rootParamaters[3].Descriptor.ShaderRegister = 1;//レジスタ番号１を使う
+
+	descriptionRootSignature.pParameters = rootParamaters;//ルートパラメータ配列へのポインタ
+	descriptionRootSignature.NumParameters = _countof(rootParamaters);//
+#pragma endregion
+
+
+
+	D3D12_STATIC_SAMPLER_DESC staticSamplers[1] = {};
+	staticSamplers[0].Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;//バイリニアフィルタ
+	staticSamplers[0].AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;//0～1の範囲外をリピート
+	staticSamplers[0].AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;//
+	staticSamplers[0].AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;//
+	staticSamplers[0].ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;//比較しない
+	staticSamplers[0].MaxLOD = D3D12_FLOAT32_MAX;//ありったけのMipmapを使う
+	staticSamplers[0].ShaderRegister = 0;//レジスタ番号0を使う
+	staticSamplers[0].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;//PixelShaderで使う
+
+	descriptionRootSignature.pStaticSamplers = staticSamplers;
+	descriptionRootSignature.NumStaticSamplers = _countof(staticSamplers);
+
+	// ルートシグネチャのシリアライズ結果を格納するBlob
+	Microsoft::WRL::ComPtr <ID3DBlob> signatureBlob = nullptr;
+	// エラーメッセージが発生した場合に格納するBlob
+	Microsoft::WRL::ComPtr <ID3DBlob> errorBlob = nullptr;
+	HRESULT hr = D3D12SerializeRootSignature(&descriptionRootSignature, D3D_ROOT_SIGNATURE_VERSION_1, &signatureBlob, &errorBlob);
+	if (FAILED(hr)) {
+		Logger::Log(reinterpret_cast<char*>(errorBlob->GetBufferPointer()));
+		assert(false);
+	}
+	hr = dxCommon_->GetDevice()->CreateRootSignature(0, signatureBlob->GetBufferPointer(), signatureBlob->GetBufferSize(), IID_PPV_ARGS(&rootSignature));
+	assert(SUCCEEDED(hr));
+
+}
+
+void Object3DCommon::CreateGraficsPipeLine()
+{
+	CreateRootSignatrue();
+
+	// 頂点の位置データを表すセマンティクスを設定
+	inputElementDescs[0].SemanticName = "POSITION";
+	inputElementDescs[0].SemanticIndex = 0;
+	inputElementDescs[0].Format = DXGI_FORMAT_R32G32B32A32_FLOAT;
+	inputElementDescs[0].AlignedByteOffset = D3D12_APPEND_ALIGNED_ELEMENT;
+	// テクスチャ座標データを表すセマンティクスの座標
+	inputElementDescs[1].SemanticName = "TEXCOORD";
+	inputElementDescs[1].SemanticIndex = 0;
+	inputElementDescs[1].Format = DXGI_FORMAT_R32G32_FLOAT;
+	inputElementDescs[1].AlignedByteOffset = D3D12_APPEND_ALIGNED_ELEMENT;
+	// 法線データを表すセマンティクスを設定
+	inputElementDescs[2].SemanticName = "NORMAL";
+	inputElementDescs[2].SemanticIndex = 0;
+	inputElementDescs[2].Format = DXGI_FORMAT_R32G32B32_FLOAT;
+	inputElementDescs[2].AlignedByteOffset = D3D12_APPEND_ALIGNED_ELEMENT;
+
+	inputLayoutDescs.pInputElementDescs = inputElementDescs;
+	inputLayoutDescs.NumElements = _countof(inputElementDescs);
+
+	// レンダーターゲットの書き込みマスクを設定。全ての色チャンネルに書き込みを許可
+	blendDesc.RenderTarget[0].RenderTargetWriteMask =
+		D3D12_COLOR_WRITE_ENABLE_ALL;
+
+
+	// カリングモードを設定
+	rasterizerDesc.CullMode = D3D12_CULL_MODE_NONE;
+	// ポリゴンのフィルモードを設定。ポリゴンの塗り潰し
+	rasterizerDesc.FillMode = D3D12_FILL_MODE_SOLID;
+
+	//　頂点シェーダーのコンパイル結果を格納するBlob
+	vertexShaderBlob = dxCommon_->CompileShader(
+		L"resources/shaders/Object3D.VS.hlsl", L"vs_6_0");
+	assert(vertexShaderBlob != nullptr);
+	// ピクセルシェーダーのコンパイル結果を格納するBlob
+	pixelShaderBlob = dxCommon_->CompileShader(
+		L"resources/shaders/Object3D.PS.hlsl", L"ps_6_0");
+	assert(pixelShaderBlob != nullptr);
+
+
+	//Depthの機能を有効化する
+	depthStencilDesc.DepthEnable = true;
+	//書き込みします
+	depthStencilDesc.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ALL;
+	//比較関数はLessEqual。つまり、近ければ描画される
+	depthStencilDesc.DepthFunc = D3D12_COMPARISON_FUNC_LESS_EQUAL;
+
+#pragma region GraphicsPipelineState
+
+	// グラフィックスパイプラインのステートオブジェクトのデスクリプタを設定
+	D3D12_GRAPHICS_PIPELINE_STATE_DESC graphicsPipelineStateDesc{};
+	graphicsPipelineStateDesc.pRootSignature = rootSignature.Get();
+	// インプットレイアウトの設定
+	graphicsPipelineStateDesc.InputLayout = inputLayoutDescs;
+	// シェーダーの設定
+	graphicsPipelineStateDesc.VS = { vertexShaderBlob->GetBufferPointer(),vertexShaderBlob->GetBufferSize() };//
+	graphicsPipelineStateDesc.PS = { pixelShaderBlob->GetBufferPointer(),pixelShaderBlob->GetBufferSize() };//
+	// ブレンドステートの設定
+	graphicsPipelineStateDesc.BlendState = blendDesc;
+	// ラスタライザの設定
+	graphicsPipelineStateDesc.RasterizerState = rasterizerDesc;
+	// レンダーターゲットの設定
+	graphicsPipelineStateDesc.NumRenderTargets = 1;
+	graphicsPipelineStateDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
+	// プリミティブとポロ時の設定
+	graphicsPipelineStateDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+	graphicsPipelineStateDesc.SampleDesc.Count = 1;
+	graphicsPipelineStateDesc.SampleMask = D3D12_DEFAULT_SAMPLE_MASK;
+	// DepthStencilの設定
+	graphicsPipelineStateDesc.DepthStencilState = depthStencilDesc;
+	graphicsPipelineStateDesc.DSVFormat = DXGI_FORMAT_D24_UNORM_S8_UINT;
+	HRESULT hr = dxCommon_->GetDevice()->CreateGraphicsPipelineState(
+		&graphicsPipelineStateDesc, IID_PPV_ARGS(&graphicsPipelineState));
+	assert(SUCCEEDED(hr));
+#pragma endregion
+
 }

--- a/Object3DCommon.h
+++ b/Object3DCommon.h
@@ -1,10 +1,46 @@
 #pragma once
-
+#include "DirectXCommon.h"
 // 3Dオブジェクト共通部
 class Object3DCommon
 {
 public:	// メンバ関数
 	// 初期化
-	void Initialize();
+	void Initialize(DirectXCommon* dxCommon);
+	// 共通描画設定
+	void DrawSettingCommon();
+public:	// Getter/Setter
+	// DirectXCommon
+	DirectXCommon* GetDxCommon()const { return dxCommon_; }
+	
+private:	// メンバ関数
+	// ルートシグネチャの作成
+	void CreateRootSignatrue();
+	// グラフィックスパイプラインの生成
+	void CreateGraficsPipeLine();
+
+
+private:	// メンバ変数
+	// 絶対にnew,deleteしない
+	DirectXCommon* dxCommon_;
+	// RootSignature作成
+	D3D12_ROOT_SIGNATURE_DESC descriptionRootSignature{};
+	// 入力レイアウトの記述を設定
+	D3D12_INPUT_LAYOUT_DESC inputLayoutDescs{};
+	// 頂点シェーダーのコンパイル結果を格納するBlob
+	Microsoft::WRL::ComPtr<IDxcBlob> vertexShaderBlob = nullptr;
+	// ピクセルシェーダーのコンパイル結果を格納するBlob
+	Microsoft::WRL::ComPtr<IDxcBlob> pixelShaderBlob = nullptr;
+	// ブレンドステートの設定
+	D3D12_BLEND_DESC blendDesc{};
+	// ラスタライザーステートの設定
+	D3D12_RASTERIZER_DESC rasterizerDesc{};
+	// DepthStencilStateの設定
+	D3D12_DEPTH_STENCIL_DESC depthStencilDesc{};
+	// ルートシグネチャ
+	Microsoft::WRL::ComPtr <ID3D12RootSignature> rootSignature = nullptr;
+	// パイプラインステートの作成
+	Microsoft::WRL::ComPtr <ID3D12PipelineState> graphicsPipelineState = nullptr;
+	// 入力要素の定義配列を初期化
+	D3D12_INPUT_ELEMENT_DESC inputElementDescs[3] = {};
 };
 

--- a/Sprite.cpp
+++ b/Sprite.cpp
@@ -37,7 +37,7 @@ void Sprite::Update()
 	}
 
 	const DirectX::TexMetadata& metadata = TextureManager::GetInstance()->GetMetadata(textureIndex);
-	
+
 	float texleft = textureLeftTop.x / metadata.width;
 	float texright = (textureLeftTop.x + textureSize.x) / metadata.width;
 	float textop = textureLeftTop.y / metadata.height;
@@ -144,18 +144,9 @@ void Sprite::CreateVertexResourceData()
 	indexData[0] = 0; indexData[1] = 1; indexData[2] = 2;
 	indexData[3] = 1; indexData[4] = 3; indexData[5] = 2;
 
-
-
-
-
 	// VertexResourceにデータを書き込むためのアドレスを取得してvertexDataに割り当てる
 	vertexData = nullptr;	// nullptrを代入しておく
 	vertexResource->Map(0, nullptr, reinterpret_cast<void**>(&vertexData));	// マップする
-
-
-
-
-
 
 }
 

--- a/SpriteCommon.cpp
+++ b/SpriteCommon.cpp
@@ -86,6 +86,7 @@ void SpriteCommon::DrawSettingCommon()
 	
 	// RootSignatureを設定。PSOに設定しているけど別途設定が必要
 	dxCommon_->GetCommandList()->SetGraphicsRootSignature(rootSignature.Get());
+
 	dxCommon_->GetCommandList()->SetPipelineState(graphicsPipelineState.Get());  // PSOを設定
 
 	// 形状を設定。PSOに設定しているものとはまた別。同じものを設定すると考えておけば良い

--- a/main.cpp
+++ b/main.cpp
@@ -169,7 +169,7 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 
 	// 3Dオブジェクト共通部の初期化
 	Object3DCommon* object3DCommon = new Object3DCommon();
-	object3DCommon->Initialize();
+	object3DCommon->Initialize(dxCommon);
 
 
 #pragma endregion 
@@ -216,40 +216,8 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 
 
 
-	// SpriteCommon移植済み
-	//// ルートシグネチャのシリアライズ結果を格納するBlob
-	//Microsoft::WRL::ComPtr <ID3DBlob> signatureBlob = nullptr;
-	//// エラーメッセージが発生した場合に格納するBlob
-	//Microsoft::WRL::ComPtr <ID3DBlob> errorBlob = nullptr;
-	//HRESULT hr = D3D12SerializeRootSignature(&descriptionRootSignature, D3D_ROOT_SIGNATURE_VERSION_1, &signatureBlob, &errorBlob);
-	//if (FAILED(hr)) {
-	//	Log(reinterpret_cast<char*>(errorBlob->GetBufferPointer()));
-	//	assert(false);
-	//}
-	//SpriteCommon移植済み
-	//	D3D12_GRAPHICS_PIPELINE_STATE_DESC graphicsPipelineStateDesc{};
-	//	graphicsPipelineStateDesc.pRootSignature = rootSignature.Get();//
-	//	graphicsPipelineStateDesc.InputLayout = inputLayoutDescs;//
-	//	graphicsPipelineStateDesc.VS = { vertexShaderBlob->GetBufferPointer(),vertexShaderBlob->GetBufferSize() };//
-	//	graphicsPipelineStateDesc.PS = { pixelShaderBlob->GetBufferPointer(),pixelShaderBlob->GetBufferSize() };//
-	//	graphicsPipelineStateDesc.BlendState = blendDesc;//
-	//	graphicsPipelineStateDesc.RasterizerState = rasterizerDesc;//
-	//	//
-	//	graphicsPipelineStateDesc.NumRenderTargets = 1;
-	//	graphicsPipelineStateDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
-	//	//
-	//	graphicsPipelineStateDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-	//	//
-	//	graphicsPipelineStateDesc.SampleDesc.Count = 1;
-	//	graphicsPipelineStateDesc.SampleMask = D3D12_DEFAULT_SAMPLE_MASK;
-	//	//
-	//	//DepthStencilの設定
-	//	graphicsPipelineStateDesc.DepthStencilState = depthStencilDesc;
-	//	graphicsPipelineStateDesc.DSVFormat = DXGI_FORMAT_D24_UNORM_S8_UINT;
-	//	Microsoft::WRL::ComPtr <ID3D12PipelineState> graphicsPipelineState = nullptr;
-	//	hr = device->CreateGraphicsPipelineState(&graphicsPipelineStateDesc, IID_PPV_ARGS(&graphicsPipelineState));
-	//
-	//	assert(SUCCEEDED(hr));
+	
+
 
 	//	const uint32_t kSubdivision = 64;		//分割数 16or32
 	//	Transform uvTransformSprite{
@@ -270,19 +238,7 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 	//
 	//
 	//
-	//	//Sprite用のマテリアルリソースを作る
-	//	Microsoft::WRL::ComPtr <ID3D12Resource> materialResourceSprite = CreateBufferResource(device, sizeof(Material));
-	//	Material* materialDataSprite = nullptr;
-	//	materialResourceSprite->Map(0, nullptr, reinterpret_cast<void**>(&materialDataSprite));
-	//	materialDataSprite->color = Vector4(1.0f, 1.0f, 1.0f, 1.0f);
-	//	materialDataSprite->enableLighting = 0;
-	//	materialDataSprite->uvTransform = MakeIdentity4x4();
-	//	Microsoft::WRL::ComPtr <ID3D12Resource> directionalLightResource = CreateBufferResource(device, sizeof(DirectionalLight));
-	//	DirectionalLight* directionalLightData = nullptr;
-	//	directionalLightResource->Map(0, nullptr, reinterpret_cast<void**>(&directionalLightData));
-	//	directionalLightData->color = { 1.0f,1.0f,1.0f,1.0f };
-	//	directionalLightData->direction = { 0.0f,-1.0f,0.0f };
-	//	directionalLightData->intensity = 1.0f;
+	
 	//
 	//
 	//	//モデル読み込み
@@ -298,7 +254,7 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 	//	vertexResource->Map(0, nullptr, reinterpret_cast<void**>(&vertexData));//書き込むためのアドレスを取得
 	//	std::memcpy(vertexData, modelData.vertices.data(), sizeof(VertexData) * modelData.vertices.size());//頂点データをリソースにコピー
 	//
-	//
+	
 	//
 	//#pragma region スフィア用の新規作成
 	//
@@ -571,7 +527,6 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 
 		for (Sprite* sprite : sprites) {
 			sprite->Update();
-
 		}
 
 		//		//三角形の回転
@@ -628,8 +583,10 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 
 
 		//DirectXの描画準備。全ての描画に共通のグラフィックスコマンドを積む
-
 		dxCommon->PreDraw();
+		
+		// 3Dオブジェクトの描画準備。3Dオブジェクトの描画に共通のグラフィックスコマンドを積む
+		object3DCommon->DrawSettingCommon();
 
 		//Spriteの描画準備。Spriteの描画に共通のグラフィックスコマンドを積む
 		spriteCommon->DrawSettingCommon();


### PR DESCRIPTION
Object3DCommonの初期化と描画設定の改善

Object3DCommon.cppにLogger.hのインクルードを追加。
Object3DCommon::InitializeメソッドがDirectXCommon* dxCommonを受け取るように変更され、dxCommon_メンバ変数に代入し、CreateGraficsPipeLineメソッドを呼び出すように。 Object3DCommon::DrawSettingCommonメソッドを追加し、ルートシグネチャやグラフィックスパイプラインの設定を行うように。 Object3DCommon::CreateRootSignatrueメソッドを追加し、ルートシグネチャの作成処理を実装。 Object3DCommon::CreateGraficsPipeLineメソッドを追加し、グラフィックスパイプラインの生成処理を実装。 Object3DCommon.hにDirectXCommon.hのインクルードを追加。
Object3DCommonクラスにDirectXCommon* dxCommon_メンバ変数を追加。 Sprite.cppのSprite::Updateメソッドに空行を追加。
Sprite.cppのSprite::CreateVertexResourceDataメソッドでvertexDataの初期化をnullptrに変更。 SpriteCommon.cppのSpriteCommon::DrawSettingCommonメソッドでSetPipelineStateの呼び出しを追加。 main.cppのWinMain関数でObject3DCommonの初期化時にdxCommonを渡すように変更し、不要なコメントアウトされたコードを削除。object3DCommon->DrawSettingCommonの呼び出しを追加。