### PR TITLE
６章完了/ブランチ切るの忘れた

### DIFF
--- a/CG2_DirectX.vcxproj
+++ b/CG2_DirectX.vcxproj
@@ -110,6 +110,9 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClCompile Include="Logger.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="MakeMatrix.cpp" />
+    <ClCompile Include="Model.cpp" />
+    <ClCompile Include="ModelCommon.cpp" />
+    <ClCompile Include="ModelManager.cpp" />
     <ClCompile Include="Object3D.cpp" />
     <ClCompile Include="Object3DCommon.cpp" />
     <ClCompile Include="Sprite.cpp" />
@@ -133,6 +136,9 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClInclude Include="Logger.h" />
     <ClInclude Include="MakeMatrix.h" />
     <ClInclude Include="Math.h" />
+    <ClInclude Include="Model.h" />
+    <ClInclude Include="ModelCommon.h" />
+    <ClInclude Include="ModelManager.h" />
     <ClInclude Include="Object3D.h" />
     <ClInclude Include="Object3DCommon.h" />
     <ClInclude Include="Sprite.h" />

--- a/CG2_DirectX.vcxproj.filters
+++ b/CG2_DirectX.vcxproj.filters
@@ -78,6 +78,15 @@
     <ClCompile Include="Object3D.cpp">
       <Filter>ソース ファイル</Filter>
     </ClCompile>
+    <ClCompile Include="Model.cpp">
+      <Filter>ソース ファイル</Filter>
+    </ClCompile>
+    <ClCompile Include="ModelCommon.cpp">
+      <Filter>ソース ファイル</Filter>
+    </ClCompile>
+    <ClCompile Include="ModelManager.cpp">
+      <Filter>ソース ファイル</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Math.h">
@@ -141,6 +150,15 @@
       <Filter>ヘッダー ファイル</Filter>
     </ClInclude>
     <ClInclude Include="Object3D.h">
+      <Filter>ヘッダー ファイル</Filter>
+    </ClInclude>
+    <ClInclude Include="Model.h">
+      <Filter>ヘッダー ファイル</Filter>
+    </ClInclude>
+    <ClInclude Include="ModelCommon.h">
+      <Filter>ヘッダー ファイル</Filter>
+    </ClInclude>
+    <ClInclude Include="ModelManager.h">
       <Filter>ヘッダー ファイル</Filter>
     </ClInclude>
   </ItemGroup>

--- a/DirectXCommon.cpp
+++ b/DirectXCommon.cpp
@@ -663,7 +663,8 @@ DirectXCommon::CreateBufferResource(size_t sizeInBytes)
 	vertexResourceDesc.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
 	//　バッファリソースの生成
 	Microsoft::WRL::ComPtr<ID3D12Resource> vertexResource = nullptr;
-	HRESULT hr = device->CreateCommittedResource(&uploadHeapProperties, D3D12_HEAP_FLAG_NONE, &vertexResourceDesc, D3D12_RESOURCE_STATE_GENERIC_READ, nullptr, IID_PPV_ARGS(&vertexResource));
+	HRESULT hr = device->CreateCommittedResource(&uploadHeapProperties, D3D12_HEAP_FLAG_NONE, 
+		&vertexResourceDesc, D3D12_RESOURCE_STATE_GENERIC_READ, nullptr, IID_PPV_ARGS(&vertexResource));
 	assert(SUCCEEDED(hr));
 	return vertexResource;
 }

--- a/Model.cpp
+++ b/Model.cpp
@@ -1,0 +1,168 @@
+#include "Model.h"
+using namespace std;
+
+
+
+void Model::Initialize(ModelCommon* modelCommon, const string& directorypath, const string& filename)
+{
+	// ModelCommonのポインタを引数からメンバ変数に記録
+	this->modelCommon = modelCommon;
+	// モデル読み込み
+	//LoadMaterialTempLateFile("resources", "plane.obj");
+	modelData = LoadObjFile(directorypath, filename);
+	// 頂点データの初期化
+	CreateVertexResourceData();
+	// マテリアルの初期化
+	CreateMaterialResource();
+	// テクスチャ読み込み
+	// .objの参照しているテクスチャファイル読み込み
+	TextureManager::GetInstance()->LoadTexture(modelData.material.textureFilePath);
+	// 読み込んだテクスチャのインデックスを取得
+	TextureManager::GetInstance()->GetTextureIndexByFilePath(modelData.material.textureFilePath);
+}
+
+void Model::Draw()
+{
+	// 頂点バッファービューをセット
+	modelCommon->GetDxCommon()->GetCommandList()->IASetVertexBuffers(0, 1, &vertexBufferView);
+	// マテリアルデータをセット
+	modelCommon->GetDxCommon()->GetCommandList()->SetGraphicsRootConstantBufferView(0, materialResource->GetGPUVirtualAddress());
+	// 座標変換行列をセット
+	modelCommon->GetDxCommon()->GetCommandList()->SetGraphicsRootDescriptorTable(2, TextureManager::GetInstance()->GetSrvHandleGPU(modelData.material.textureIndex));
+
+	// テクスチャをセット
+	//modelCommon->GetDxCommon()->GetCommandList()->SetGraphicsRoot32BitConstant(3, modelData.material.textureIndex, 0);
+	// 描画
+	modelCommon->GetDxCommon()->GetCommandList()->DrawInstanced(UINT(modelData.vertices.size()), 1, 0, 0);
+
+}
+
+ModelData Model::LoadObjFile(const std::string& directoryPath, const std::string& filename)
+{
+
+	// 1. 必要な変数宣言
+	ModelData modelData;			// 構築するModelData
+	vector<Vector4> positions;		// 位置
+	vector<Vector3> normals;		// 法線
+	vector<Vector2> texcoords;		// テクスチャ座標
+	string line;					// ファイルから読んだ1行を格納
+
+	// 2. ファイルを開く
+	ifstream file(directoryPath + "/" + filename);
+	assert(file.is_open());         // 開けなかったら止める
+
+	while (getline(file, line)) {
+		string identifier;
+		istringstream s(line);
+		s >> identifier; // 先頭の識別子を読む
+
+		// identifierに応じた処理
+		if (identifier == "v") {
+			Vector4 position;
+			s >> position.x >> position.y >> position.z;
+			position.x *= -1;
+			position.w = 1.0f;
+			positions.push_back(position);
+		}
+		else if (identifier == "vt") {
+			Vector2 texcoord;
+			s >> texcoord.x >> texcoord.y;
+			texcoord.y = 1.0f - texcoord.y;
+			texcoords.push_back(texcoord);
+		}
+		else if (identifier == "vn") {
+			Vector3 normal;
+			s >> normal.x >> normal.y >> normal.z;
+			normal.x *= -1;
+			normals.push_back(normal);
+		}
+		else if (identifier == "f") {
+			VertexData triangle[3];
+			// 面は三角形限定。その他は未定。
+			for (int32_t faceVertex = 0; faceVertex < 3; ++faceVertex) {
+				string vertexDefinition;
+				s >> vertexDefinition;
+				// 頂点の要素へのIndexは　［位置/UV/法線］　で格納されているので分解してIndexを取得する
+				istringstream v(vertexDefinition);
+				uint32_t elementIndices[3];
+				for (int32_t element = 0; element < 3; ++element) {
+					string index;
+					getline(v, index, '/');      // 区切りでインデックスうぃ読んでいく
+					elementIndices[element] = stoi(index);
+				}
+				// 要素へのIndexから、実際の要素の値を取得して、頂点を構築する
+				Vector4 position = positions[elementIndices[0] - 1];
+				Vector2 texcoord = texcoords[elementIndices[1] - 1];
+				Vector3 normal = normals[elementIndices[2] - 1];
+
+				triangle[faceVertex] = { position,texcoord,normal };
+			}
+			// 頂点を逆順すろことで、回り順を逆にする
+			modelData.vertices.push_back(triangle[2]);
+			modelData.vertices.push_back(triangle[1]);
+			modelData.vertices.push_back(triangle[0]);
+		}
+		else if (identifier == "mtllib") {
+			std::string materialFilename;
+			s >> materialFilename;
+			modelData.material = LoadMaterialTempLateFile(directoryPath, materialFilename);
+		}
+	}
+	return modelData;
+}
+
+
+
+MaterialData Model::LoadMaterialTempLateFile(const std::string& directoryPath, const std::string& filename)
+{
+	MaterialData materialData;	//構築するMaterialData
+	std::string line;			//ファイルから読んだ１行を格納するもの
+	std::ifstream file(directoryPath + "/" + filename);//ファイルを開く
+	assert(file.is_open());		//開けなかったら止める
+
+	while (std::getline(file, line)) {
+		std::string identifier;
+		std::istringstream s(line);
+		s >> identifier;
+		//identifierに応じた処理
+		if (identifier == "map_Kd") {
+			std::string textureFilename;
+			s >> textureFilename;
+			//連結してファイルパスにする
+			materialData.textureFilePath = directoryPath + "/" + textureFilename;
+		}
+	}
+	return materialData;
+}
+
+void Model::CreateVertexResourceData()
+{
+	// 頂点バッファーリソースを作成
+	vertexResource = modelCommon->GetDxCommon()->CreateBufferResource(sizeof(VertexData) * modelData.vertices.size());
+	// 頂点バッファーリソースにデータを書き込む
+	vertexResource->Map(0, nullptr, reinterpret_cast<void**>(&vertexData));
+	memcpy(vertexData, modelData.vertices.data(), sizeof(VertexData) * modelData.vertices.size());
+	// 頂点バッファービューを作成
+	// リソースの先頭のアドレスから使用
+	vertexBufferView.BufferLocation = vertexResource->GetGPUVirtualAddress();
+	// 使用するリソースのサイズは頂点のサイズ
+	vertexBufferView.SizeInBytes = UINT(sizeof(VertexData) * modelData.vertices.size());
+	vertexBufferView.StrideInBytes = sizeof(VertexData);
+	//書き込むためのアドレスを取得
+	vertexResource->Map(0, nullptr, reinterpret_cast<void**>(&vertexData));
+	//頂点データをリソースにコピー
+	memcpy(vertexData, modelData.vertices.data(), sizeof(VertexData) * modelData.vertices.size());
+}
+
+void Model::CreateMaterialResource()
+{
+	// マテリアルリソースを作成
+	materialResource = modelCommon->GetDxCommon()->CreateBufferResource(sizeof(Material));
+	// マテリアルリソースにデータを書き込むためのアドレスを取得してmaterialDataに割り当てる
+	materialResource->Map(0, nullptr, reinterpret_cast<void**>(&materialData));
+	// マテリアルデータの初期化
+	materialData->color = { 1.0f, 1.0f, 1.0f, 1.0f };
+	materialData->enableLighting = 0;
+	materialData->uvTransform = MakeIdentity4x4();
+
+}

--- a/Model.h
+++ b/Model.h
@@ -1,0 +1,61 @@
+#pragma once
+#include "ModelCommon.h"
+#include "Math.h"
+#include "TextureManager.h"
+#include <string>
+#include <vector>
+#include <fstream>
+#include <cassert>
+#include <wrl.h>
+#include <d3d12.h>
+#include "MakeMatrix.h"
+using namespace std;
+class Model
+{
+public: // メンバ関数
+	// 初期化
+	void Initialize(ModelCommon* modelCommon,const string& directorypath,const string&filename);
+	// 更新
+	void Update();
+	// 描画
+	void Draw();
+
+
+	// objファイルの読み込み
+	ModelData LoadObjFile(const std::string& directoryPath, const std::string& filename);
+public: // Getter/Setter
+	// モデルデータの取得
+	ModelData GetModelData()const { return modelData; }
+	// バッファリソースの取得
+	Microsoft::WRL::ComPtr<ID3D12Resource> GetVertexResource()const { return vertexResource; }
+	// バッファリソースの使い道を補足するバッファービューの取得
+	D3D12_VERTEX_BUFFER_VIEW GetVertexBufferView()const { return vertexBufferView; }
+	// マテリアルリソースの取得
+	Microsoft::WRL::ComPtr<ID3D12Resource> GetMaterialResource()const { return materialResource; }
+	// マテリアルデータの取得
+	Material* GetMaterialData()const { return materialData; }
+private: // メンバ関数
+	// モデルデータの読み込み
+	MaterialData LoadMaterialTempLateFile(const std::string& directoryPath, const std::string& filename);
+	// 頂点リソースデータの作成
+	void CreateVertexResourceData();
+	// マテリアルリソースの作成
+	void CreateMaterialResource();
+
+private:
+	// メンバ変数
+	ModelCommon* modelCommon = nullptr;
+	// モデルデータ
+	ModelData modelData;
+	// バッファリソース
+	Microsoft::WRL::ComPtr<ID3D12Resource> vertexResource;
+	// バッファリソースの使い道を補足するバッファービュー
+	D3D12_VERTEX_BUFFER_VIEW vertexBufferView{};
+	// バッファリソース内のデータを指すポインタ
+	VertexData* vertexData = nullptr;
+	// バッファリソース
+	Microsoft::WRL::ComPtr<ID3D12Resource> materialResource;
+	// マテリアルデータ
+	Material* materialData = nullptr;
+};
+

--- a/ModelCommon.cpp
+++ b/ModelCommon.cpp
@@ -1,0 +1,11 @@
+#include "ModelCommon.h"
+
+ModelCommon::ModelCommon()
+{
+}
+
+void ModelCommon::Initialize(DirectXCommon* dxCommon)
+{
+	//引数で受け取ってメンバ変数に記録する
+	this->dxCommon_ = dxCommon;
+}

--- a/ModelCommon.h
+++ b/ModelCommon.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "DirectXCommon.h"
+class ModelCommon
+{
+public:	// メンバ関数
+	ModelCommon();
+	~ModelCommon();
+	// 初期化
+	void Initialize(DirectXCommon* dxCommon);
+	// 共通描画設定
+	void DrawSettingCommon();
+public:	// Getter/Setter
+	// DirectXCommon
+	DirectXCommon* GetDxCommon()const { return dxCommon_; }
+private:
+	// 絶対にnew,deleteしない
+	DirectXCommon* dxCommon_;
+
+};
+

--- a/ModelManager.cpp
+++ b/ModelManager.cpp
@@ -1,0 +1,53 @@
+#include "ModelManager.h"
+
+ModelManager* ModelManager::instance = nullptr;
+
+ModelManager* ModelManager::GetInstance()
+{
+	if (instance == nullptr)
+	{
+		instance = new ModelManager();
+	}
+	return instance;
+}
+
+void ModelManager::Finalize()
+{
+	delete instance;
+	instance = nullptr;
+}
+
+void ModelManager::Initialize(DirectXCommon* dxCommon)
+{
+	modelCommon = new ModelCommon();
+	modelCommon->Initialize(dxCommon);
+}
+
+void ModelManager::LoadModel(const string& filePath)
+{
+	// 読み込み済みモデルを検索
+	if (models.contains(filePath))
+	{
+		// 読み込み済みなら早期リターン
+		return;
+	}
+	// モデルの生成とファイル読み込み、初期化
+	unique_ptr<Model>model = make_unique<Model>();
+	model->Initialize(modelCommon, "resources", filePath);
+
+	// モデルリストに追加
+	//models[filePath] = move(model);
+	models.insert(make_pair(filePath, move(model)));
+}
+
+Model* ModelManager::FindModel(const string& filePath)
+{
+	// 読み込み済みモデルを検索
+	if (models.contains(filePath))
+	{
+		// 読み込みモデルを戻り値として返す
+		return models.at(filePath).get();
+	}
+	// 読み込み済みでない場合はnullptrを返す
+	return nullptr;
+}

--- a/ModelManager.h
+++ b/ModelManager.h
@@ -1,0 +1,40 @@
+#pragma once
+#include "ModelCommon.h"
+#include "Math.h"
+#include "TextureManager.h"
+#include <string>
+#include <vector>
+#include <fstream>
+#include "Model.h"
+#include <map>
+using namespace std;
+// Path: ModelManager.h
+class ModelManager
+{
+public: // メンバ関数
+	// シングルトンインスタンスを取得
+	static ModelManager* GetInstance();
+	// シングルトンインスタンスを解放
+	void Finalize();
+
+	// 初期化
+	void Initialize(DirectXCommon* dxCommon);
+	// モデルファイルの読み込み
+	void LoadModel(const string& filePath);
+public: // Getter/Setter
+	// モデルデータの取得
+	Model* FindModel(const string& filePath);
+
+private: // メンバ変数シングルトン
+	static ModelManager* instance;
+	ModelManager() = default;
+	~ModelManager() = default;
+	ModelManager(ModelManager&) = delete;
+	ModelManager& operator=(ModelManager&) = delete;
+private: // メンバ変数
+	ModelCommon* modelCommon = nullptr;
+	// モデルデータのリスト
+	map<string, unique_ptr<Model>> models;
+
+};
+

--- a/Object3D.cpp
+++ b/Object3D.cpp
@@ -4,19 +4,15 @@
 #include <sstream>
 #include <cassert>
 #include "MakeMatrix.h"
+#include "ModelManager.h"
 using namespace std;
 void Object3D::Initialize(Object3DCommon* obj3dCommon)
 {
 	this->object3DCommon = obj3dCommon;
-	modelData = LoadObjFile("resources", "plane.obj");
-	CreateVertexResourceData();
-	CreateMaterialResource();
+	
+
 	CreateTransformationMatrixData();
 	CreateDirectionalLightResource();
-	// .objの参照しているテクスチャファイル読み込み
-	TextureManager::GetInstance()->LoadTexture(modelData.material.textureFilePath);
-	// 読み込んだテクスチャのインデックスを取得
-	TextureManager::GetInstance()->GetTextureIndexByFilePath(modelData.material.textureFilePath);
 
 	// Transformの初期化
 	transform={ { 1.0f, 1.0f, 1.0f },{ 0.0f, 0.0f, 0.0f }, { 0.0f, 0.0f, 0.0f  } };
@@ -32,155 +28,28 @@ void Object3D::Update()
 	Matrix4x4 worldViewProjection = Multiply(worldMatrix, Multiply(viewMatrix, projectionMatrix));
 	wvpData->WVP = worldViewProjection;
 	wvpData->World = worldMatrix;
-
-
 }
 
 void Object3D::Draw()
-{
-	// 頂点バッファービューをセット
-	object3DCommon->GetDxCommon()->GetCommandList()->IASetVertexBuffers(0, 1, &vertexBufferView);
-	// マテリアルデータをセット
-	object3DCommon->GetDxCommon()->GetCommandList()->SetGraphicsRootConstantBufferView(0, materialResource->GetGPUVirtualAddress());
-	// 座標変換行列をセット
+{// 座標変換行列をセット
 	object3DCommon->GetDxCommon()->GetCommandList()->SetGraphicsRootConstantBufferView(1, wvpResource->GetGPUVirtualAddress());
-	object3DCommon->GetDxCommon()->GetCommandList()->SetGraphicsRootDescriptorTable(2, TextureManager::GetInstance()->GetSrvHandleGPU(modelData.material.textureIndex) );
 	// 平行光源データをセット
 	object3DCommon->GetDxCommon()->GetCommandList()->SetGraphicsRootConstantBufferView(3, directionalLightResource->GetGPUVirtualAddress());
-	// テクスチャをセット
-	//object3DCommon->GetDxCommon()->GetCommandList()->SetGraphicsRoot32BitConstant(3, modelData.material.textureIndex, 0);
-	// 描画
-	object3DCommon->GetDxCommon()->GetCommandList()->DrawInstanced(UINT(modelData.vertices.size()), 1, 0, 0);
-}
-
-MaterialData Object3D::LoadMaterialTempLateFile(const std::string& directoryPath, const std::string& filename)
-{
-	MaterialData materialData;	//構築するMaterialData
-	std::string line;			//ファイルから読んだ１行を格納するもの
-	std::ifstream file(directoryPath + "/" + filename);//ファイルを開く
-	assert(file.is_open());		//開けなかったら止める
-
-	while (std::getline(file, line)) {
-		std::string identifier;
-		std::istringstream s(line);
-		s >> identifier;
-		//identifierに応じた処理
-		if (identifier == "map_Kd") {
-			std::string textureFilename;
-			s >> textureFilename;
-			//連結してファイルパスにする
-			materialData.textureFilePath = directoryPath + "/" + textureFilename;
-		}
+	// 3Dモデルが割り当てられていれば描画する
+	if (model) {
+		model->Draw();
 	}
-	return materialData;
 }
 
-ModelData Object3D::LoadObjFile(const std::string& directoryPath, const std::string& filename)
+void Object3D::SetModel(const std::string& filePath)
 {
-	// 1. 必要な変数宣言
-	ModelData modelData;     // 構築するModelData
-	vector<Vector4> positions;    // 位置
-	vector<Vector3> normals;    // 法線
-	vector<Vector2> texcoords;    // テクスチャ座標
-	string line;       // ファイルから読んだ1行を格納
-
-	// 2. ファイルを開く
-	ifstream file(directoryPath + "/" + filename);
-	assert(file.is_open());         // 開けなかったら止める
-
-	while (getline(file, line)) {
-		string identifier;
-		istringstream s(line);
-		s >> identifier; // 先頭の識別子を読む
-
-		// identifierに応じた処理
-		if (identifier == "v") {
-			Vector4 position;
-			s >> position.x >> position.y >> position.z;
-			position.x *= -1;
-			position.w = 1.0f;
-			positions.push_back(position);
-		}
-		else if (identifier == "vt") {
-			Vector2 texcoord;
-			s >> texcoord.x >> texcoord.y;
-			texcoord.y = 1.0f - texcoord.y;
-			texcoords.push_back(texcoord);
-		}
-		else if (identifier == "vn") {
-			Vector3 normal;
-			s >> normal.x >> normal.y >> normal.z;
-			normal.x *= -1;
-			normals.push_back(normal);
-		}
-		else if (identifier == "f") {
-			VertexData triangle[3];
-			// 面は三角形限定。その他は未定。
-			for (int32_t faceVertex = 0; faceVertex < 3; ++faceVertex) {
-				string vertexDefinition;
-				s >> vertexDefinition;
-				// 頂点の要素へのIndexは　［位置/UV/法線］　で格納されているので分解してIndexを取得する
-				istringstream v(vertexDefinition);
-				uint32_t elementIndices[3];
-				for (int32_t element = 0; element < 3; ++element) {
-					string index;
-					getline(v, index, '/');      // 区切りでインデックスうぃ読んでいく
-					elementIndices[element] = stoi(index);
-				}
-				// 要素へのIndexから、実際の要素の値を取得して、頂点を構築する
-				Vector4 position = positions[elementIndices[0] - 1];
-				Vector2 texcoord = texcoords[elementIndices[1] - 1];
-				Vector3 normal = normals[elementIndices[2] - 1];
-
-				triangle[faceVertex] = { position,texcoord,normal };
-			}
-			// 頂点を逆順すろことで、回り順を逆にする
-			modelData.vertices.push_back(triangle[2]);
-			modelData.vertices.push_back(triangle[1]);
-			modelData.vertices.push_back(triangle[0]);
-		}
-		else if (identifier == "mtllib") {
-			std::string materialFilename;
-			s >> materialFilename;
-			modelData.material = LoadMaterialTempLateFile(directoryPath, materialFilename);
-		}
-	}
-	return modelData;
+	// モデルを検索してセットする
+	model = ModelManager::GetInstance()->FindModel(filePath);
 }
 
-void Object3D::CreateVertexResourceData()
-{
-	// 頂点バッファーリソースを作成
-	vertexResource = object3DCommon->GetDxCommon()->CreateBufferResource(sizeof(VertexData) * modelData.vertices.size());
-	// 頂点バッファーリソースにデータを書き込む
-	vertexResource->Map(0, nullptr, reinterpret_cast<void**>(&vertexData));
-	std::memcpy(vertexData, modelData.vertices.data(), sizeof(VertexData) * modelData.vertices.size());
-	// 頂点バッファービューを作成
-	// リソースの先頭のアドレスから使用
-	vertexBufferView.BufferLocation = vertexResource->GetGPUVirtualAddress();
-	// 使用するリソースのサイズは頂点のサイズ
-	vertexBufferView.SizeInBytes = UINT(sizeof(VertexData) * modelData.vertices.size());
-	vertexBufferView.StrideInBytes = sizeof(VertexData);
-	//書き込むためのアドレスを取得
-	vertexResource->Map(0, nullptr, reinterpret_cast<void**>(&vertexData));
-	//頂点データをリソースにコピー
-	memcpy(vertexData, modelData.vertices.data(), sizeof(VertexData) * modelData.vertices.size());
-
-}
-
-void Object3D::CreateMaterialResource()
-{
-	// マテリアルリソースを作成
-	materialResource = object3DCommon->GetDxCommon()->CreateBufferResource(sizeof(Material));
-	// マテリアルリソースにデータを書き込むためのアドレスを取得してmaterialDataに割り当てる
-	materialResource->Map(0, nullptr, reinterpret_cast<void**>(&materialData));
-	// マテリアルデータの初期化
-	materialData->color = { 1.0f, 1.0f, 1.0f, 1.0f };
-	materialData->enableLighting = 0;
-	materialData->uvTransform = MakeIdentity4x4();
 
 
-}
+
 
 void Object3D::CreateTransformationMatrixData()
 {

--- a/Object3D.h
+++ b/Object3D.h
@@ -5,12 +5,13 @@
 #include <vector>
 #include <wrl.h>
 #include "TextureManager.h"
+#include "Object3DCommon.h"
+#include "Model.h"
 // 3Dオブジェクト
 // 3Dオブジェクト共通部前方宣言
 class Object3DCommon;
 class Object3D
 {
-	
 
 public:	// メンバ関数
 	// 初期化
@@ -19,37 +20,31 @@ public:	// メンバ関数
 	void Update();
 	// 描画
 	void Draw();
-	// モデルデータの読み込み
-	MaterialData LoadMaterialTempLateFile(const std::string& directoryPath, const std::string& filename);
-	// objファイルの読み込み
-	ModelData LoadObjFile(const std::string& directoryPath, const std::string& filename);
+
+
 
 public:	// Getter/Setter
+	void SetModel(Model* model) { this->model = model; }
+	void SetModel(const std::string& filePath);
+	void SetScale(const Vector3& scale) { transform.scale = scale; }
+	void SetRotate(const Vector3& rotate) { transform.rotate = rotate; }
+	void SetTranslate(const Vector3& translate) { transform.translate = translate; }
 
+	const Vector3 GetScale()const { return transform.scale; }
+	const Vector3 GetRotate()const { return transform.rotate; }
+	const Vector3 GetTranslate()const { return transform.translate; }
 private: // メンバ関数
-	// 頂点リソースデータの作成
-	void CreateVertexResourceData();
-	// マテリアルリソースの作成
-	void CreateMaterialResource();
 	// 座標変換行列リソースの作成
 	void CreateTransformationMatrixData();
 	// 平行光源リソースの作成
 	void CreateDirectionalLightResource();
+
+	
 private:// メンバ変数
 	// 3Dオブジェクト共通部
 	Object3DCommon* object3DCommon = nullptr;
 	// モデルデータ
-	ModelData modelData;
-	// バッファリソース
-	Microsoft::WRL::ComPtr<ID3D12Resource> vertexResource;
-	// バッファリソース内のデータを指すポインタ
-	VertexData* vertexData = nullptr;
-	// バッファリソースの使い道を補足するバッファービュー
-	D3D12_VERTEX_BUFFER_VIEW vertexBufferView{};
-	// バッファリソース
-	Microsoft::WRL::ComPtr<ID3D12Resource> materialResource;
-	// マテリアルデータ
-	Material* materialData = nullptr;
+	Model* model = nullptr;
 	// バッファリソース / 座標変換行列リソース
 	Microsoft::WRL::ComPtr<ID3D12Resource> wvpResource;
 	// バッファリソース内のデータを指すポインタ

--- a/Object3DCommon.h
+++ b/Object3DCommon.h
@@ -18,7 +18,6 @@ private:	// メンバ関数
 	// グラフィックスパイプラインの生成
 	void CreateGraficsPipeLine();
 
-
 private:	// メンバ変数
 	// 絶対にnew,deleteしない
 	DirectXCommon* dxCommon_;

--- a/main.cpp
+++ b/main.cpp
@@ -29,7 +29,9 @@
 #include "TextureManager.h"
 #include "Object3D.h"
 #include "Object3DCommon.h"
-
+#include "Model.h"
+#include "ModelCommon.h"
+#include "ModelManager.h"
 using namespace Logger;
 #pragma comment(lib,"d3d12.lib")
 #pragma comment(lib,"dxgi.lib")
@@ -65,7 +67,9 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 
 	// テクスチャマネージャーの初期化
 	TextureManager::GetInstance()->Initialize(dxCommon);
-
+	// 3Dモデルマネージャの初期化
+	ModelManager::GetInstance()->Initialize(dxCommon);
+	
 	// スプライト共通部の初期化
 	SpriteCommon* spriteCommon = new SpriteCommon();
 	spriteCommon->Initialize(dxCommon);
@@ -73,6 +77,10 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 	// 3Dオブジェクト共通部の初期化
 	Object3DCommon* object3DCommon = new Object3DCommon();
 	object3DCommon->Initialize(dxCommon);
+
+	// モデル共通部の初期化
+	ModelCommon* modelCommon = new ModelCommon();
+	modelCommon->Initialize(dxCommon);
 
 
 #pragma endregion 
@@ -82,6 +90,20 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 	// 
 	Object3D* object3D = new Object3D();
 	object3D->Initialize(object3DCommon);
+
+	Model* model = new Model();
+	model->Initialize(modelCommon,"resources","axis.obj");
+	ModelManager::GetInstance()->LoadModel("axis.obj");
+	object3D->SetModel("axis.obj");
+
+	// モデルをもう一つ読み込む
+	Model* model2 = new Model();
+	model2->Initialize(modelCommon, "resources", "plane.obj");
+	ModelManager::GetInstance()->LoadModel("plane.obj");
+	Object3D* object3D2 = new Object3D();
+	object3D2->Initialize(object3DCommon);
+	object3D2->SetModel("plane.obj");
+
 
 	std::vector<Sprite*> sprites;
 	//std::vector<Sprite*> sprites2;
@@ -417,7 +439,7 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 		//ゲームの処理
 		input->Update();
 		object3D->Update();
-
+		object3D2->Update();
 		if (input->TriggerKey(DIK_1)) {
 			OutputDebugStringA("Hit_1\n");
 		}
@@ -482,6 +504,7 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 		// 3Dオブジェクトの描画準備。3Dオブジェクトの描画に共通のグラフィックスコマンドを積む
 		object3DCommon->DrawSettingCommon();
 		object3D->Draw();
+		object3D2->Draw();
 		//Spriteの描画準備。Spriteの描画に共通のグラフィックスコマンドを積む
 		spriteCommon->DrawSettingCommon();
 
@@ -558,6 +581,8 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 
 	//CloseHandle(fenceEvent);
 	TextureManager::GetInstance()->Finalize();
+	// モデルマネージャの終了処理
+	ModelManager::GetInstance()->Finalize();
 	winAPI->Finalize();
 
 #pragma endregion
@@ -574,6 +599,9 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 	for (Sprite* sprite : sprites) {
 		delete sprite;
 	}
+	delete model2;
+	delete object3D2;
+	delete model;
 	delete object3D;
 	delete object3DCommon;
 	delete spriteCommon;


### PR DESCRIPTION
プロジェクトにモデル管理機能を追加

`CG2_DirectX.vcxproj` に `Model.cpp`、`ModelCommon.cpp`、`ModelManager.cpp` のソースファイルと `Model.h`、`ModelCommon.h`、`ModelManager.h` のヘッダーファイルを追加しました。 `CG2_DirectX.vcxproj.filters` にも同様に追加しました。
`DirectXCommon.cpp` の `CreateBufferResource` メソッドで、`CreateCommittedResource` の呼び出しを改行して見やすくしました。 `Object3D.cpp` に `ModelManager.h` をインクルードし、`Object3D` クラスの初期化メソッドでモデルデータの読み込みとテクスチャの設定を削除しました。また、`SetModel` メソッドを追加し、モデルの描画処理を簡素化しました。 `Object3D.h` に `Model` クラスのインクルードと、モデルの設定用のメソッドを追加しました。また、不要なメソッドとメンバ変数を削除しました。 `Object3DCommon.h` のプライベートメンバ変数の位置を変更しました。
`main.cpp` に `Model.h`、`ModelCommon.h`、`ModelManager.h` をインクルードし、`WinMain` 関数内で `ModelManager` の初期化と終了処理を追加しました。また、`Object3D` インスタンスにモデルを設定する処理を追加し、複数のモデルと `Object3D` インスタンスを作成するようにしました。 `main.cpp` の `WinMain` 関数内で、`object3D2` の更新と描画処理を追加しました。 `main.cpp` の終了処理で、`model2`、`object3D2`、`model` の削除を追加しました。 `Model.cpp` に `#include "Model.h"` と `using namespace std;` を追加し、`Model` クラスに `Initialize`、`Draw`、`LoadObjFile`、`LoadMaterialTempLateFile`、`CreateVertexResourceData`、`CreateMaterialResource` メソッドを追加しました。 `Model.h` に `#pragma once` と必要なヘッダーファイルのインクルードを追加し、`Model` クラスを定義しました。 `ModelCommon.cpp` に `#include "ModelCommon.h"` を追加し、`ModelCommon` クラスのコンストラクタと `Initialize` メソッドを追加しました。 `ModelCommon.h` に `#pragma once` と必要なヘッダーファイルのインクルードを追加し、`ModelCommon` クラスを定義しました。 `ModelManager.cpp` に `#include "ModelManager.h"` を追加し、`ModelManager` クラスのシングルトンインスタンスを管理するためのメンバ変数 `instance` を追加しました。 `ModelManager.h` に `#pragma once` と必要なヘッダーファイルのインクルードを追加し、`ModelManager` クラスを定義しました。