### PR TITLE
ファイル分け

### DIFF
--- a/CG2_DirectX.vcxproj.filters
+++ b/CG2_DirectX.vcxproj.filters
@@ -16,12 +16,21 @@
     <Filter Include="imgui">
       <UniqueIdentifier>{594812c4-8a90-4be3-a6d0-a97173671ae6}</UniqueIdentifier>
     </Filter>
+    <Filter Include="ソース ファイル\3d">
+      <UniqueIdentifier>{5acd36b9-5656-455c-a4b4-d43ab72a4b96}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ソース ファイル\2d">
+      <UniqueIdentifier>{36fac186-041e-4da4-8bf8-4d83e6a3c83d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ソース ファイル\bace">
+      <UniqueIdentifier>{6b872dcb-1519-4c01-bb9b-1d8524eb2f8a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ソース ファイル\math">
+      <UniqueIdentifier>{1ed84c41-44ce-4800-8160-b51a1ff42753}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp">
-      <Filter>ソース ファイル</Filter>
-    </ClCompile>
-    <ClCompile Include="MakeMatrix.cpp">
       <Filter>ソース ファイル</Filter>
     </ClCompile>
     <ClCompile Include="externals\imgui\imgui.cpp">
@@ -45,47 +54,50 @@
     <ClCompile Include="externals\imgui\imgui_widgets.cpp">
       <Filter>imgui</Filter>
     </ClCompile>
-    <ClCompile Include="Input.cpp">
-      <Filter>ソース ファイル</Filter>
-    </ClCompile>
     <ClCompile Include="WinAPI.cpp">
-      <Filter>ソース ファイル</Filter>
+      <Filter>ソース ファイル\bace</Filter>
     </ClCompile>
     <ClCompile Include="DirectXCommon.cpp">
-      <Filter>ソース ファイル</Filter>
-    </ClCompile>
-    <ClCompile Include="Logger.cpp">
-      <Filter>ソース ファイル</Filter>
-    </ClCompile>
-    <ClCompile Include="StringUtility.cpp">
-      <Filter>ソース ファイル</Filter>
+      <Filter>ソース ファイル\bace</Filter>
     </ClCompile>
     <ClCompile Include="D3DResourceLeakChecker.cpp">
-      <Filter>ソース ファイル</Filter>
-    </ClCompile>
-    <ClCompile Include="SpriteCommon.cpp">
-      <Filter>ソース ファイル</Filter>
-    </ClCompile>
-    <ClCompile Include="Sprite.cpp">
-      <Filter>ソース ファイル</Filter>
-    </ClCompile>
-    <ClCompile Include="TextureManager.cpp">
-      <Filter>ソース ファイル</Filter>
-    </ClCompile>
-    <ClCompile Include="Object3DCommon.cpp">
-      <Filter>ソース ファイル</Filter>
+      <Filter>ソース ファイル\bace</Filter>
     </ClCompile>
     <ClCompile Include="Object3D.cpp">
-      <Filter>ソース ファイル</Filter>
+      <Filter>ソース ファイル\3d</Filter>
+    </ClCompile>
+    <ClCompile Include="Object3DCommon.cpp">
+      <Filter>ソース ファイル\3d</Filter>
+    </ClCompile>
+    <ClCompile Include="SpriteCommon.cpp">
+      <Filter>ソース ファイル\2d</Filter>
+    </ClCompile>
+    <ClCompile Include="Sprite.cpp">
+      <Filter>ソース ファイル\2d</Filter>
+    </ClCompile>
+    <ClCompile Include="StringUtility.cpp">
+      <Filter>ソース ファイル\bace</Filter>
+    </ClCompile>
+    <ClCompile Include="Logger.cpp">
+      <Filter>ソース ファイル\bace</Filter>
     </ClCompile>
     <ClCompile Include="Model.cpp">
-      <Filter>ソース ファイル</Filter>
+      <Filter>ソース ファイル\3d</Filter>
     </ClCompile>
     <ClCompile Include="ModelCommon.cpp">
-      <Filter>ソース ファイル</Filter>
+      <Filter>ソース ファイル\3d</Filter>
     </ClCompile>
     <ClCompile Include="ModelManager.cpp">
-      <Filter>ソース ファイル</Filter>
+      <Filter>ソース ファイル\3d</Filter>
+    </ClCompile>
+    <ClCompile Include="TextureManager.cpp">
+      <Filter>ソース ファイル\2d</Filter>
+    </ClCompile>
+    <ClCompile Include="MakeMatrix.cpp">
+      <Filter>ソース ファイル\math</Filter>
+    </ClCompile>
+    <ClCompile Include="Input.cpp">
+      <Filter>ソース ファイル\bace</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
プロジェクトフィルターの追加と変更

`CG2_DirectX.vcxproj.filters` に新しいフィルター「ソース ファイル\3d」、「ソース ファイル\2d」、「ソース ファイル\bace」、「ソース ファイル\math」を追加しました。`MakeMatrix.cpp`、`Input.cpp`、`WinAPI.cpp`、`DirectXCommon.cpp`、`D3DResourceLeakChecker.cpp`、`Object3D.cpp`、`Object3DCommon.cpp`、`SpriteCommon.cpp`、`Sprite.cpp`、`TextureManager.cpp`、`StringUtility.cpp`、`Logger.cpp`、`Model.cpp`、`ModelCommon.cpp`、`ModelManager.cpp` の各ファイルのフィルターを変更しました。具体的には、`MakeMatrix.cpp` は「ソース ファイル\math」に、`Input.cpp`、`WinAPI.cpp`、`DirectXCommon.cpp`、`D3DResourceLeakChecker.cpp`、`StringUtility.cpp`、`Logger.cpp` は「ソース ファイル\bace」に、`Object3D.cpp`、`Object3DCommon.cpp`、`Model.cpp`、`ModelCommon.cpp`、`ModelManager.cpp` は「ソース ファイル\3d」に、`SpriteCommon.cpp`、`Sprite.cpp`、`TextureManager.cpp` は「ソース ファイル\2d」に移動しました。さらに、`MakeMatrix.cpp`、`Input.cpp`、`D3DResourceLeakChecker.cpp`、`StringUtility.cpp`、`Logger.cpp`、`Object3D.cpp`、`Object3DCommon.cpp`、`Sprite.cpp`、`TextureManager.cpp` を再度追加しましたが、フィルターが変更されています。