### PR TITLE
資料分完了

### DIFF
--- a/imgui.ini
+++ b/imgui.ini
@@ -30,6 +30,6 @@ Collapsed=0
 
 [Window][plane]
 Pos=83,68
-Size=256,107
+Size=256,214
 Collapsed=0
 


### PR DESCRIPTION
カメラ制御とパーティクル機能の追加

- `imgui.ini` ファイルの `[Window][plane]` セクションで、ウィンドウのサイズが `256,107` から `256,214` に変更されました。
- `main.cpp` ファイルの `WinMain` 関数内で、`cameraTransform` の初期化が変更されました。具体的には、回転の初期値が `{ 0.0f, 0.0f, 0.0f }` から `{std::numbers::pi_v<float> / 3.0f, std::numbers::pi_v<float>, 0.0f}` に変更されました。
- `main.cpp` ファイルの `WinMain` 関数内で、新しい行 `Matrix4x4 backToFrontMatrix = MakeRotateYMatrix(std::numbers::pi_v<float>);` が追加されました。
- パーティクルの色のアルファ値を計算するコードが移動され、`instancingData[numInstance].color.w = alpha;` の位置が変更されました。
- スケール行列、平行移動行列、ビルボード行列の計算が追加され、`worldMatrix` と `worldViewProjectionMatrix` の計算が更新されました。
- ImGui ウィンドウにカメラの移動を制御するための `ImGui::DragFloat3("cameraTranslate", &cameraTransform.translate.x, 0.05f);` が追加されました。
- パーティクル発生用のボタンが追加されました。