### PR TITLE
Finalize関数にオブジェクト削除処理を追加

### DIFF
--- a/project/Framework.cpp
+++ b/project/Framework.cpp
@@ -77,16 +77,26 @@ void Framework::Update()
 	if (input->TriggerKey(DIK_ESCAPE)) {
 		isEndRequst = true;
 	}
-	
 
+}
 
 
 void Framework::Finalize()
 {
-	// delete audio;
+
 	delete input;
 	delete dxCommon;
 	winAPI->Finalize();
+	delete srvManager;
+	TextureManager::GetInstance()->Finalize();
+	delete spriteCommon;
+	delete modelCommon;
+	delete object3DCommon;
+	delete camera;
+	ModelManager::GetInstance()->Finalize();
+#ifdef _DEBUG
+		delete	imGui;
+#endif
 	delete winAPI;
 	audio->SoundUnload(&soundData);
 	audio->Finalize();

--- a/project/MyGame.h
+++ b/project/MyGame.h
@@ -43,31 +43,7 @@ public:	// メンバ関数
 
 
 private:	// メンバ変数
-	// SRVマネージャー
-	SrvManager* srvManager = nullptr;
-	// スプライト共通部
-	SpriteCommon* spriteCommon = nullptr;
-	// 3Dモデルマネージャー
-	ModelManager* modelManager = nullptr;
-	// 3Dオブジェクト共通部
-	Object3DCommon* object3DCommon = nullptr;
-	// カメラ
-	Camera* camera = nullptr;
-	// ImGui
-#ifdef _DEBUG
-	//ImGuiManager* imGui = nullptr;
-#endif
-
-	// スプライト
-	std::vector<Sprite*> sprites;
-	// 3Dオブジェクト
-	Object3D* object3D = nullptr;
-	// 3Dモデル
-	Model* model = nullptr;
-	// modelCommon
-	ModelCommon* modelCommon = nullptr;
-
-
+	
 
 };
 


### PR DESCRIPTION
Framework::Finalize() 関数において、input、srvManager、spriteCommon、modelCommon、object3DCommon、camera、imGui（デバッグモードのみ）などのオブジェクトの削除処理を追加しました。また、MyGame.h ファイルから複数のメンバ変数（srvManager、spriteCommon、modelManager、object3DCommon、camera、imGui（デバッグモードのみ）、sprites、object3D、model、modelCommon）を削除しました。