### PR TITLE
確認完了

### DIFF
--- a/project/AbstractSceneFactory.cpp
+++ b/project/AbstractSceneFactory.cpp
@@ -1,0 +1,1 @@
+#include "AbstractSceneFactory.h"

--- a/project/AbstractSceneFactory.h
+++ b/project/AbstractSceneFactory.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "BaseScene.h"
+#include <string>
+// シーン工場クラス
+class AbstractSceneFactory
+{
+public:
+	// 仮想デストラクタv
+	virtual ~AbstractSceneFactory() = default;
+	// シーン生成
+	virtual BaseScene* CreateScene(const std::string&sceneName) = 0;
+};
+

--- a/project/BaseScene.h
+++ b/project/BaseScene.h
@@ -1,17 +1,25 @@
 #pragma once
 #include "DirectXCommon.h"
-// シーン基底クラス
+
+class SceneManager;
+
 class BaseScene
 {
 public:
-	virtual ~BaseScene() = default;
-	// 初期化
-	virtual void Initialize(DirectXCommon* dxCommon) = 0;
-	// 更新
-	virtual void Update() = 0;
-	// 描画
-	virtual void Draw() = 0;
-	// 終了処理
-	virtual void Finalize() = 0;
+    virtual ~BaseScene() = default;
+    // 初期化
+    virtual void Initialize(DirectXCommon* dxCommon) = 0;
+    // 更新
+    virtual void Update() = 0;
+    // 描画
+    virtual void Draw() = 0;
+    // 終了処理
+    virtual void Finalize() = 0;
+    // Setter
+    virtual void SetSceneManager(SceneManager* sceneManager) { this->sceneManager = sceneManager; }
+
+protected:
+    // シーンマネージャー
+    SceneManager* sceneManager = nullptr;
 };
 

--- a/project/CG2_DirectX.vcxproj
+++ b/project/CG2_DirectX.vcxproj
@@ -103,6 +103,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="AbstractSceneFactory.cpp" />
     <ClCompile Include="Audio.cpp" />
     <ClCompile Include="BaseScene.cpp" />
     <ClCompile Include="Camera.cpp" />
@@ -127,10 +128,13 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClCompile Include="MyGame.cpp" />
     <ClCompile Include="ParticleEmitter.cpp" />
     <ClCompile Include="ParticleManager.cpp" />
+    <ClCompile Include="SceneFactory.cpp" />
+    <ClCompile Include="SceneManager.cpp" />
     <ClCompile Include="SrvManager.cpp" />
     <ClCompile Include="TitleScene.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="AbstractSceneFactory.h" />
     <ClInclude Include="Audio.h" />
     <ClInclude Include="BaseScene.h" />
     <ClInclude Include="Camera.h" />
@@ -155,6 +159,8 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClInclude Include="MyGame.h" />
     <ClInclude Include="ParticleEmitter.h" />
     <ClInclude Include="ParticleManager.h" />
+    <ClInclude Include="SceneFactory.h" />
+    <ClInclude Include="SceneManager.h" />
     <ClInclude Include="SrvManager.h" />
     <ClInclude Include="TitleScene.h" />
   </ItemGroup>

--- a/project/CG2_DirectX.vcxproj.filters
+++ b/project/CG2_DirectX.vcxproj.filters
@@ -108,6 +108,15 @@
     <ClCompile Include="BaseScene.cpp">
       <Filter>ソース ファイル</Filter>
     </ClCompile>
+    <ClCompile Include="SceneManager.cpp">
+      <Filter>ソース ファイル</Filter>
+    </ClCompile>
+    <ClCompile Include="AbstractSceneFactory.cpp">
+      <Filter>ソース ファイル</Filter>
+    </ClCompile>
+    <ClCompile Include="SceneFactory.cpp">
+      <Filter>ソース ファイル</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="engine\math\MyMath.h">
@@ -186,6 +195,15 @@
       <Filter>ヘッダー ファイル</Filter>
     </ClInclude>
     <ClInclude Include="BaseScene.h">
+      <Filter>ヘッダー ファイル</Filter>
+    </ClInclude>
+    <ClInclude Include="SceneManager.h">
+      <Filter>ヘッダー ファイル</Filter>
+    </ClInclude>
+    <ClInclude Include="AbstractSceneFactory.h">
+      <Filter>ヘッダー ファイル</Filter>
+    </ClInclude>
+    <ClInclude Include="SceneFactory.h">
       <Filter>ヘッダー ファイル</Filter>
     </ClInclude>
   </ItemGroup>

--- a/project/Framework.cpp
+++ b/project/Framework.cpp
@@ -10,8 +10,8 @@ void Framework::Initialize()
 	dxCommon->Initialize(winAPI);
 
 	// 入力処理のクラスポインタ
-	input = new Input();
-	input->Initialize(winAPI);
+	
+	Input::GetInstance()->Initialize(winAPI);
 
 	// SRVマネージャーの初期化
 	srvManager = new SrvManager();
@@ -47,6 +47,7 @@ void Framework::Initialize()
 
 #pragma endregion
 
+	
 
 }
 
@@ -60,12 +61,14 @@ void Framework::Update()
 		return;
 	}
 #pragma endregion
+	SceneManager::GetInstance()->Update(dxCommon);
 
-	input->Update();
+	Input::GetInstance()->Update();
 
 
 	// ESCキーで終了
-	if (input->TriggerKey(DIK_ESCAPE)) {
+	if (Input::GetInstance()->TriggerKey(DIK_ESCAPE))
+	{
 		isEndRequst = true;
 	}
 
@@ -74,10 +77,11 @@ void Framework::Update()
 
 void Framework::Finalize()
 {
-
-	delete input;
+	delete sceneFactory_;
+	SceneManager::GetInstance()->Finalize();
 	delete dxCommon;
 	winAPI->Finalize();
+	Input::GetInstance()->DeleteInstance();
 	delete srvManager;
 	TextureManager::GetInstance()->Finalize();
 	delete modelCommon;

--- a/project/Framework.h
+++ b/project/Framework.h
@@ -21,7 +21,8 @@
 #include "ModelManager.h"
 #include "ImGuiManager.h"
 #include "Audio.h"
-
+#include "SceneManager.h"
+#include "AbstractSceneFactory.h"
 class Framework
 {
 
@@ -45,15 +46,11 @@ protected:
 	// 終了リクエスト
 	bool isEndRequst = false;
 
-private:
-	D3DResourceLeakChecker leakCheck;
 protected:// Initialize関連
 	// ウィンドウAPI
 	WinAPI* winAPI = nullptr;
 	// DirectX共通部
 	DirectXCommon* dxCommon = nullptr;
-	// 入力処理
-	Input* input = nullptr;
 	// ImGui
 #ifdef _DEBUG
 	ImGuiManager* imGui = nullptr;
@@ -72,6 +69,14 @@ protected:// Initialize関連
 	Object3DCommon* object3DCommon = nullptr;
 	// カメラ
 	Camera* camera = nullptr;
+public:
+	// シーンファクトリー
+	AbstractSceneFactory* sceneFactory_ = nullptr;
+private:
+	// リークチェッカー
+	D3DResourceLeakChecker leakCheck;
+	
+
 	
 };
 

--- a/project/GamePlayScene.cpp
+++ b/project/GamePlayScene.cpp
@@ -12,7 +12,7 @@ void GamePlayScene::Initialize(DirectXCommon* dxCommon)
 {
 	// オーディオの初期化
 	Audio::GetInstance()->Initialize();
-	soundData = Audio::GetInstance()->LoadWave("resources/fanfare.wav");
+	soundData = Audio::GetInstance()->LoadWave("resources/mokugyo.wav");
 	xaudio2_ = Audio::GetInstance()->GetXAudio2();
 	Audio::GetInstance()->SoundPlayWave(xaudio2_, soundData);
 

--- a/project/MyGame.cpp
+++ b/project/MyGame.cpp
@@ -1,16 +1,15 @@
 #include "MyGame.h"
-
+#include "SceneFactory.h"
 void MyGame::Initialize()
 {
 	Framework::Initialize();
-	// ゲームプレイシーンの初期化
-	scene_ = new TitleScene();
-	scene_->Initialize(dxCommon);
-#pragma region 最初のシーンの初期化
-	// 3Dオブジェクトの初期化
 
-#pragma endregion
-
+	// シーンファクトリーの生成
+	sceneFactory_ = new SceneFactory();
+	SceneManager::GetInstance()->SetSceneFactory(sceneFactory_);
+	// シーンmanagerに最初のシーンをセット
+	SceneManager::GetInstance()->ChangeScene("TITLE");
+	
 }
 
 void MyGame::Update()
@@ -18,31 +17,19 @@ void MyGame::Update()
 	Framework::Update();
 
 #pragma region ゲームの更新
-	// アクターの更新
-
-	// ゲームプレイシーンの更新
-	scene_->Update();
 	
+
 #pragma endregion
 
 #ifdef _DEBUG // デバッグ時のみ有効ImGuiの処理
 	// ImGuiの処理
 	imGui->Begin();
-#endif
 
-	
-#ifdef _DEBUG
-	
 	ImGui::Text("Hello, world %d", 123);
 	if (ImGui::Button("Save")) {
 		OutputDebugStringA("Save\n");
 	}
-
-
-	
 	imGui->End();
-	
-
 #endif
 }
 
@@ -51,14 +38,14 @@ void MyGame::Draw()
 	// DirectXの描画準備。全ての描画に共通のグラフィックスコマンドを積む
 	dxCommon->PreDraw();
 	srvManager->PreDraw();
-	// ゲームプレイシーンの描画
-	scene_->Draw();
+	
 	// 3Dオブジェクトの描画準備。3Dオブジェクトの描画に共通のグラフィックスコマンドを積む
 	object3DCommon->DrawSettingCommon();
-	
-	
 
-	
+
+	// シーンマネージャーの描画	
+	SceneManager::GetInstance()->Draw();
+	// 3Dオブジェクトの描画
 #ifdef _DEBUG
 	// ImGuiの描画
 	imGui->Draw();
@@ -80,9 +67,7 @@ void MyGame::Finalize()
 	ModelManager::GetInstance()->Finalize();
 	winAPI->Finalize();
 
-	// ゲームプレイシーンの終了処理
-	scene_->Finalize();
-	delete scene_;
+	
 
 #pragma endregion
 

--- a/project/MyGame.h
+++ b/project/MyGame.h
@@ -44,9 +44,7 @@ public:	// メンバ関数
 
 
 private:	// メンバ変数
-	// ゲームプレイシーンクラス
-	TitleScene* scene_ = nullptr;
-	// タイトルシーンクラス
-	//TitleScene* titleScene_ = nullptr;
+	
+
 };
 

--- a/project/SceneFactory.cpp
+++ b/project/SceneFactory.cpp
@@ -1,0 +1,17 @@
+#include "SceneFactory.h"
+#include "TitleScene.h"
+#include "GamePlayScene.h"
+BaseScene* SceneFactory::CreateScene(const std::string& sceneName)
+{
+    // 次のシーン生成
+	BaseScene* scene = nullptr;
+	if (sceneName == "TITLE")
+	{
+		scene = new TitleScene();
+	}
+	else if (sceneName == "GAMEPLAY")
+	{
+		scene = new GamePlayScene();
+	}
+	return scene;
+}

--- a/project/SceneFactory.h
+++ b/project/SceneFactory.h
@@ -1,0 +1,9 @@
+#pragma once
+#include "AbstractSceneFactory.h"
+class SceneFactory : public AbstractSceneFactory
+{
+public:
+	// シーン生成
+	BaseScene* CreateScene(const std::string& sceneName)override;
+};
+

--- a/project/SceneManager.cpp
+++ b/project/SceneManager.cpp
@@ -1,0 +1,67 @@
+#include "SceneManager.h"
+
+static SceneManager* instance = nullptr;
+
+
+SceneManager* SceneManager::GetInstance()
+{
+	if (instance == nullptr)
+	{
+		instance = new SceneManager();
+	}
+	return instance;
+}
+
+void SceneManager::Update(DirectXCommon* dxCommon)
+{
+    // 次のシーンが予約されている場合
+    if (nextScene_) {
+        // 今のシーンの終了処理
+        if (scene_) {
+            scene_->Finalize();
+            delete scene_;
+        }
+        // 次のシーンの初期化
+        scene_ = nextScene_;
+        nextScene_ = nullptr;
+        // シーンマネージャーの設定
+        scene_->SetSceneManager(this);
+        scene_->Initialize(dxCommon);
+    }
+    // 実行中シーンを更新
+    if (scene_) {
+        scene_->Update();
+    }
+}
+
+void SceneManager::Draw()
+{
+    // 実行中シーンが存在する場合のみ描画
+    if (scene_) {
+        scene_->Draw();
+    }
+}
+
+void SceneManager::Finalize()
+{
+    // 最後のシーンの終了処理
+    // 使えるようなら
+    if (scene_)
+    {
+        scene_->Finalize();
+        delete scene_;
+    }
+}
+
+void SceneManager::ChangeScene(const std::string& sceneName)
+{
+    assert(sceneFactory_);
+    assert(nextScene_ == nullptr);
+
+	// 次のシーン生成
+	nextScene_ = sceneFactory_->CreateScene(sceneName);
+}
+
+
+
+

--- a/project/SceneManager.h
+++ b/project/SceneManager.h
@@ -1,0 +1,43 @@
+#pragma once
+#include "BaseScene.h"
+#include "AbstractSceneFactory.h"
+// シーン管理クラス
+// シングルトンクラス
+class SceneManager
+{
+public:
+	// インスタンスの取得
+	static SceneManager* GetInstance();
+	// コンストラクタ
+	SceneManager() = default;
+	// デストラクタ 
+	~SceneManager() = default;
+	// コピーコンストラクタ
+	SceneManager(SceneManager&) = delete;
+	// 代入演算子のオーバーロード
+	SceneManager& operator=(SceneManager&) = delete;
+
+	// 更新
+	void Update(DirectXCommon*dxCommon);
+	// 描画
+	void Draw();
+	// 終了処理
+	void Finalize();
+
+public:
+	// シーンファクトリーのSetter
+	void SetSceneFactory(AbstractSceneFactory* sceneFactory) { sceneFactory_ = sceneFactory; }
+	// シーンチェンジ
+	void ChangeScene(const std::string& sceneName);
+
+private:
+	// 今のシーン
+	BaseScene* scene_ = nullptr;
+	// 次のシーン
+	BaseScene* nextScene_ = nullptr;
+
+	// シーンファクトリー // 借り物
+	AbstractSceneFactory* sceneFactory_ = nullptr;
+	
+};
+

--- a/project/TitleScene.cpp
+++ b/project/TitleScene.cpp
@@ -1,7 +1,8 @@
 #include "TitleScene.h"
-
+#include "Input.h"
 TitleScene::TitleScene()
 {
+	
 }
 
 TitleScene::~TitleScene()
@@ -9,7 +10,11 @@ TitleScene::~TitleScene()
 }
 
 void TitleScene::Initialize(DirectXCommon* dxCommon)
-{// オーディオの初期化
+{
+	
+
+
+	// オーディオの初期化
 	Audio::GetInstance()->Initialize();
 	soundData = Audio::GetInstance()->LoadWave("resources/fanfare.wav");
 	xaudio2_ = Audio::GetInstance()->GetXAudio2();
@@ -17,20 +22,37 @@ void TitleScene::Initialize(DirectXCommon* dxCommon)
 
 	// スプライトの初期化
 	SpriteCommon::GetInstance()->Initialize(dxCommon);
+
+	sprite_ = new Sprite();
+	sprite_->Initialize(SpriteCommon::GetInstance(), "resources/monsterball.png");
+	sprite_->SetPosition({ 0.0f,0.0f });
+	sprite_->SetRotation(0.0f);
+
 }
 
 void TitleScene::Update()
 {
+	sprite_->Update();
+
+	// ENTERキーが押されたら
+	if(Input::GetInstance()->TriggerKey(DIK_RETURN))
+	{
+		SceneManager::GetInstance()->ChangeScene("GAMEPLAY");
+	}
 }
 
 void TitleScene::Draw()
 {
 	//Spriteの描画準備。Spriteの描画に共通のグラフィックスコマンドを積む
 	SpriteCommon::GetInstance()->DrawSettingCommon();
+
+	sprite_->Draw();
 }
 
 void TitleScene::Finalize()
 {
+	delete sprite_;
+
 	// オーディオの終了処理
 	Audio::GetInstance()->SoundUnload(&soundData);
 

--- a/project/TitleScene.h
+++ b/project/TitleScene.h
@@ -2,6 +2,9 @@
 #include "Audio.h"
 #include "SpriteCommon.h"
 #include "BaseScene.h"
+#include "Sprite.h"
+#include "SceneManager.h"
+
 class TitleScene :public BaseScene
 {
 public:
@@ -20,10 +23,16 @@ private:
 	// ゲームオブジェクト
 	// 3Dオブジェクト
 	// シーン遷移
-
+	
 	// オーディオ
 	// サウンドデータ
 	SoundData soundData;
 	IXAudio2* xaudio2_;
+
+	// スプライト
+	Sprite* sprite_ = nullptr;
+
+	
+
 };
 

--- a/project/engine/bace/Input.cpp
+++ b/project/engine/bace/Input.cpp
@@ -3,6 +3,25 @@
 #pragma comment(lib,"dinput8.lib")
 #pragma comment(lib,"dxguid.lib")
 
+Input* Input::instance = nullptr;
+Input* Input::GetInstance()
+{
+	if (instance == nullptr)
+	{
+		instance = new Input();
+	}
+	return instance;
+}
+
+void Input::DeleteInstance()
+{
+	if (instance != nullptr)
+	{
+		delete instance;
+		instance = nullptr;
+	}
+}
+
 void Input::Initialize(WinAPI *winAPI)
 {
 	//借りてきたWinAPIのインスタンスを記録

--- a/project/engine/bace/Input.h
+++ b/project/engine/bace/Input.h
@@ -6,11 +6,20 @@
 #include <wrl.h>
 #include "WinAPI.h"
 
-//LPDIRECTINPUT8 g_pDirectInput = nullptr;			//DirectInputオブジェクト
-//LPDIRECTINPUTDEVICE8 g_pKeyboarDevice = nullptr;	//キーボードデバイス
 class Input
 {
 public:
+	static Input* GetInstance();
+	static void DeleteInstance();
+private:
+	static Input* instance;
+	Input() = default;
+	~Input() = default;
+	Input(Input&) = delete;
+	Input& operator=(Input&) = delete;
+
+public:
+
 	//初期化 
 	void Initialize(WinAPI*winAPI);
 	//更新
@@ -33,5 +42,7 @@ private:
 
 	//WindowsAPI
 	WinAPI* winAPI = nullptr;
+
+	
 };
 


### PR DESCRIPTION
シーン管理とシングルトンパターンの導入

`BaseScene.h`に`SceneManager`クラスの宣言を追加し、`BaseScene`クラスにシーンマネージャーのセッターとプロテクテッドメンバーを追加しました。`CG2_DirectX.vcxproj`と`CG2_DirectX.vcxproj.filters`に新しいソースファイルとヘッダーファイルを追加しました。`Framework.cpp`の`Initialize`、`Update`、`Finalize`メソッドにおいて、`Input`クラスのシングルトンパターンへの変更と`SceneManager`の処理を追加しました。`Framework.h`に`SceneManager`と`AbstractSceneFactory`のインクルードを追加し、`sceneFactory_`メンバーを追加しました。`GamePlayScene.cpp`でサウンドデータのロードを変更しました。`MyGame.cpp`でシーンファクトリーの生成とシーンマネージャーへの設定を追加し、シーンの処理を`SceneManager`を通じて行うように変更しました。`MyGame.h`で不要なメンバ変数を削除しました。`TitleScene.cpp`でスプライトの処理とシーン変更を追加しました。`TitleScene.h`で`Sprite`と`SceneManager`のインクルードを追加し、スプライトのメンバ変数を追加しました。`Input.cpp`と`Input.h`で`Input`クラスをシングルトンパターンに変更しました。`AbstractSceneFactory.cpp`と`AbstractSceneFactory.h`でシーン工場クラスを定義しました。`SceneFactory.cpp`と`SceneFactory.h`で具体的なシーン生成クラスを定義しました。`SceneManager.cpp`と`SceneManager.h`でシーン管理クラスを定義しました。