### PR TITLE
サウンド再生とスプライト描画のコメントアウト解除

### DIFF
--- a/project/TitleScene.cpp
+++ b/project/TitleScene.cpp
@@ -11,14 +11,11 @@ TitleScene::~TitleScene()
 
 void TitleScene::Initialize(DirectXCommon* dxCommon)
 {
-	
-
-
 	// オーディオの初期化
 	Audio::GetInstance()->Initialize();
 	soundData = Audio::GetInstance()->LoadWave("resources/fanfare.wav");
 	xaudio2_ = Audio::GetInstance()->GetXAudio2();
-	// Audio::GetInstance()->SoundPlayWave(xaudio2_, soundData);
+	 Audio::GetInstance()->SoundPlayWave(xaudio2_, soundData);
 
 	// スプライトの初期化
 	SpriteCommon::GetInstance()->Initialize(dxCommon);
@@ -53,7 +50,7 @@ void TitleScene::Draw()
 	//Spriteの描画準備。Spriteの描画に共通のグラフィックスコマンドを積む
 	SpriteCommon::GetInstance()->DrawSettingCommon();
 
-	//sprite_->Draw();
+	sprite_->Draw();
 
 	// パーティクルの描画
 	ParticleManager::GetInstance()->Draw();


### PR DESCRIPTION
`TitleScene::Initialize` メソッドで `SoundPlayWave` 関数のコメントアウトを解除し、サウンドが再生されるようにしました。 `TitleScene::Update` メソッドで `sprite_->Draw()` 関数のコメントアウトを解除し、スプライトが描画されるようにしました。